### PR TITLE
Enforce semicolon-less style

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
   singleQuote: true,
-};
+  semi: false,
+}

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -9,4 +9,4 @@ module.exports = {
     'prettier/prettier': true,
     'selector-max-id': 1,
   },
-};
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "stylelint.vscode-stylelint",
+    "stylelint.vscode-stylelint"
   ]
 }

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,2 @@
 nodeLinker: node-modules
-defaultSemverRangePrefix: ""
+defaultSemverRangePrefix: ''

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,17 +1,17 @@
-import react from 'eslint-plugin-react';
-import globals from 'globals';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import js from '@eslint/js';
-import { FlatCompat } from '@eslint/eslintrc';
+import react from 'eslint-plugin-react'
+import globals from 'globals'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import js from '@eslint/js'
+import { FlatCompat } from '@eslint/eslintrc'
 
-const filename = fileURLToPath(import.meta.url);
-const dirname = path.dirname(filename);
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 const compat = new FlatCompat({
   baseDirectory: dirname,
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all,
-});
+})
 
 export default [
   {
@@ -28,6 +28,8 @@ export default [
     },
     rules: {
       'no-shadow': 'off',
+      semi: ['error', 'never'],
+      'no-extra-semi': 'error',
     },
   },
   {
@@ -35,10 +37,13 @@ export default [
     rules: {
       ...react.configs.flat.recommended.rules,
       'react/display-name': 'off',
-      'react/function-component-definition': ['error', {
-        namedComponents: 'arrow-function',
-        unnamedComponents: 'arrow-function',
-      }],
+      'react/function-component-definition': [
+        'error',
+        {
+          namedComponents: 'arrow-function',
+          unnamedComponents: 'arrow-function',
+        },
+      ],
       'react/jsx-filename-extension': 'error',
       'react/prop-types': 'off',
     },
@@ -47,9 +52,12 @@ export default [
     files: ['*.config.mjs'],
     rules: {
       'import/no-unresolved': 'off',
-      'import/no-extraneous-dependencies': ['error', {
-        devDependencies: true,
-      }],
+      'import/no-extraneous-dependencies': [
+        'error',
+        {
+          devDependencies: true,
+        },
+      ],
     },
   },
-];
+]

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,2 +1,2 @@
-import './javascripts/index.jsx';
-import './stylesheets/index.scss';
+import './javascripts/index.jsx'
+import './stylesheets/index.scss'

--- a/src/javascripts/books/book.jsx
+++ b/src/javascripts/books/book.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import dateformat from 'dateformat';
-import Tag from './tag';
+import React from 'react'
+import dateformat from 'dateformat'
+import Tag from './tag'
 
 export default ({ book }) => (
   <>
@@ -19,12 +19,20 @@ export default ({ book }) => (
               </div>
             </td>
             <td rowSpan={book.events.length}>
-              <a href={`https://np-complete-books.s3.amazonaws.com/pdf/${book.repo}.pdf`} target="_blank" rel="noreferrer">
+              <a
+                href={`https://np-complete-books.s3.amazonaws.com/pdf/${book.repo}.pdf`}
+                target="_blank"
+                rel="noreferrer"
+              >
                 [pdf]
               </a>
             </td>
             <td rowSpan={book.events.length}>
-              <a href={`https://github.com/np-complete/${book.repo}`} target="_blank" rel="noreferrer">
+              <a
+                href={`https://github.com/np-complete/${book.repo}`}
+                target="_blank"
+                rel="noreferrer"
+              >
                 [source]
               </a>
             </td>
@@ -33,4 +41,4 @@ export default ({ book }) => (
       </tr>
     ))}
   </>
-);
+)

--- a/src/javascripts/books/context.js
+++ b/src/javascripts/books/context.js
@@ -1,3 +1,3 @@
-import { createContext } from 'react';
+import { createContext } from 'react'
 
-export default createContext();
+export default createContext()

--- a/src/javascripts/books/index.jsx
+++ b/src/javascripts/books/index.jsx
@@ -1,25 +1,29 @@
-import React from 'react';
-import Context from './context';
-import Book from './book';
-import list from './list.yml';
+import React from 'react'
+import Context from './context'
+import Book from './book'
+import list from './list.yml'
 
 export default () => {
-  const [books, setBooks] = React.useState(list);
-  const [tags, setTags] = React.useState([]);
+  const [books, setBooks] = React.useState(list)
+  const [tags, setTags] = React.useState([])
 
   const toggleTag = (tag) => {
-    setTags((tags) => (tags.includes(tag) ? tags.filter((x) => x !== tag) : tags.concat(tag)));
-  };
+    setTags((tags) =>
+      tags.includes(tag) ? tags.filter((x) => x !== tag) : tags.concat(tag),
+    )
+  }
 
-  const context = React.useMemo(() => ({ tags, toggleTag }), [tags, toggleTag]);
+  const context = React.useMemo(() => ({ tags, toggleTag }), [tags, toggleTag])
 
   React.useEffect(() => {
     if (tags.length > 0) {
-      setBooks(list.filter((book) => tags.every((tag) => book.tags.includes(tag))));
+      setBooks(
+        list.filter((book) => tags.every((tag) => book.tags.includes(tag))),
+      )
     } else {
-      setBooks(list);
+      setBooks(list)
     }
-  }, [list, tags]);
+  }, [list, tags])
 
   return (
     <Context.Provider value={context}>
@@ -40,5 +44,5 @@ export default () => {
         </tbody>
       </table>
     </Context.Provider>
-  );
-};
+  )
+}

--- a/src/javascripts/books/list.yml
+++ b/src/javascripts/books/list.yml
@@ -26,7 +26,7 @@
       date: 2021-12-31
   repo: c99
   tags:
-     - Security
+    - Security
 - title: キマる Ruby
   events:
     - name: C97

--- a/src/javascripts/books/tag.jsx
+++ b/src/javascripts/books/tag.jsx
@@ -1,14 +1,22 @@
-import React from 'react';
-import classNames from 'classnames';
-import Context from './context';
+import React from 'react'
+import classNames from 'classnames'
+import Context from './context'
 
-export default ({ tag }) => {
-  const ctx = React.useContext(Context);
-  const className = classNames('button', 'is-info', 'is-small', { 'is-light': !ctx.tags.includes(tag) });
+const Tag = ({ tag }) => {
+  const ctx = React.useContext(Context)
+  const className = classNames('button', 'is-info', 'is-small', {
+    'is-light': !ctx.tags.includes(tag),
+  })
 
   return (
-    <button type="button" className={className} onClick={() => ctx.toggleTag(tag)}>
+    <button
+      type="button"
+      className={className}
+      onClick={() => ctx.toggleTag(tag)}
+    >
       {tag}
     </button>
-  );
-};
+  )
+}
+
+export default Tag

--- a/src/javascripts/index.jsx
+++ b/src/javascripts/index.jsx
@@ -1,18 +1,22 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import Books from './books';
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import Books from './books'
 
 const Main = () => (
   <section className="section">
     <div className="container">
-      <h1 id="title" className="title">NP-complete</h1>
-      <p id="subtitle" className="subtitle">プログラミング・技術書系同人サークル</p>
+      <h1 id="title" className="title">
+        NP-complete
+      </h1>
+      <p id="subtitle" className="subtitle">
+        プログラミング・技術書系同人サークル
+      </p>
       <Books />
     </div>
   </section>
-);
+)
 
 document.addEventListener('DOMContentLoaded', () => {
-  const elm = document.querySelector('#mount');
-  createRoot(elm).render(<Main />);
-});
+  const elm = document.querySelector('#mount')
+  createRoot(elm).render(<Main />)
+})

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,13 +1,10 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import yaml from '@modyfi/vite-plugin-yaml';
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import yaml from '@modyfi/vite-plugin-yaml'
 
 export default defineConfig({
   root: 'src', // Set root to src so index.html is found at /
-  plugins: [
-    react(),
-    yaml(),
-  ],
+  plugins: [react(), yaml()],
   build: {
     outDir: '../dist',
     emptyOutDir: true,
@@ -17,4 +14,4 @@ export default defineConfig({
       // If there are any specific aliases, add them here
     },
   },
-});
+})


### PR DESCRIPTION
This PR updates ESLint and Prettier configurations to disallow unnecessary semicolons and enforces a semicolon-less style across the project.

Key changes:
- Set `semi: false` in `.prettierrc.js`
- Set `semi: ['error', 'never']` and `no-extra-semi: 'error'` in `eslint.config.mjs`
- Automatically removed semicolons from existing source files using `prettier --write` and `eslint --fix`