### PR TITLE
Refactor React components to use named constants and explicit exports

### DIFF
--- a/src/javascripts/books/book.jsx
+++ b/src/javascripts/books/book.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import dateformat from 'dateformat'
 import Tag from './tag'
 
-export default ({ book }) => (
+const Book = ({ book }) => (
   <>
     {book.events.map((event, index) => (
       <tr key={event.name}>
@@ -42,3 +42,5 @@ export default ({ book }) => (
     ))}
   </>
 )
+
+export default Book

--- a/src/javascripts/books/index.jsx
+++ b/src/javascripts/books/index.jsx
@@ -3,7 +3,7 @@ import Context from './context'
 import Book from './book'
 import list from './list.yml'
 
-export default () => {
+const Books = () => {
   const [books, setBooks] = React.useState(list)
   const [tags, setTags] = React.useState([])
 
@@ -46,3 +46,5 @@ export default () => {
     </Context.Provider>
   )
 }
+
+export default Books

--- a/src/javascripts/index.jsx
+++ b/src/javascripts/index.jsx
@@ -16,6 +16,8 @@ const Main = () => (
   </section>
 )
 
+export default Main
+
 document.addEventListener('DOMContentLoaded', () => {
   const elm = document.querySelector('#mount')
   createRoot(elm).render(<Main />)


### PR DESCRIPTION
Refactor React components to follow the requested style:
- Use named constants for components.
- Use explicit `export default`.
- Use implicit return `({}) => ( ... )` for simple components without logic.